### PR TITLE
Run tests in webdriver for CI, both firefox and chrome

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,16 +21,11 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container:
-      options: --network-alias testHost
-
-    env:
-      SELENIUM_HUB: hub
-      TEST_HOST: testHost
-
     services:
       hub:
         image: selenium/hub:3.141.59-gold
+        ports:
+          - 4444:4444
       firefox:
         image: selenium/node-firefox:3.141.59-gold
         env:
@@ -47,5 +42,5 @@ jobs:
       # TODO: cache dependencies (taking into accounts: Maven plugins, snapshots, etc.)
 
       - name: Build with Maven
-        run: JAVA_HOME=$JAVA_HOME_8_X64 mvn -V -B -ntp -U -e verify -Pgithub-ci-selenium
+        run: JAVA_HOME=$JAVA_HOME_8_X64 mvn -V -B -ntp -U -e verify -Pwebdriver-tests -Dwebdriver.test.host=$(hostname)
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,12 +21,31 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      options: --network-alias testHost
 
+    env:
+      SELENIUM_HUB: hub
+      TEST_HOST: testHost
+
+    services:
+      hub:
+        image: selenium/hub:3.141.59-gold
+      firefox:
+        image: selenium/node-firefox:3.141.59-gold
+        env:
+          HUB_HOST: hub
+          HUB_PORT: 4444
+      chrome:
+        image: selenium/node-chrome:3.141.59-gold
+        env:
+          HUB_HOST: hub
+          HUB_PORT: 4444
     steps:
       - uses: actions/checkout@v2
 
       # TODO: cache dependencies (taking into accounts: Maven plugins, snapshots, etc.)
 
       - name: Build with Maven
-        run: JAVA_HOME=$JAVA_HOME_8_X64 mvn -V -B -ntp -U -e verify
+        run: JAVA_HOME=$JAVA_HOME_8_X64 mvn -V -B -ntp -U -e verify -Pgithub-ci-selenium
 

--- a/gwt-core-gwt2-tests/pom.xml
+++ b/gwt-core-gwt2-tests/pom.xml
@@ -76,11 +76,6 @@
             <artifactId>gwt-core</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-remote-driver</artifactId>
-            <version>3.141.59</version>
-        </dependency>
     </dependencies>
 
     <build>
@@ -107,8 +102,29 @@
     </build>
 
     <profiles>
+        <!-- This profile will run the test in firefox and chrome instead of htmlunit. To use it,
+             first start a local selenium hub using the same version as specified below, and start
+             the desired browsers. Default properties below expect that the hub will be running on
+             localhost:4444, and that the browsers will be able to connect to localhost where this
+             maven process is running - if using docker to run those containers, you will need to
+             specify -Dwebdriver.test.host= to be the hostname that those containers can reach.
+        -->
         <profile>
-            <id>github-ci-selenium</id>
+            <id>webdriver-tests</id>
+            <properties>
+                <webdriver.test.host>localhost</webdriver.test.host>
+                <webdriver.hub.host>localhost</webdriver.hub.host>
+                <webdriver.hub.port>4444</webdriver.hub.port>
+                <webdriver.browsers>firefox,chrome</webdriver.browsers>
+                <webdriver.version>3.141.59</webdriver.version>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.seleniumhq.selenium</groupId>
+                    <artifactId>selenium-remote-driver</artifactId>
+                    <version>${webdriver.version}</version>
+                </dependency>
+            </dependencies>
             <build>
                 <plugins>
                     <plugin>
@@ -116,11 +132,11 @@
                         <artifactId>gwt-maven-plugin</artifactId>
                         <configuration>
                             <systemProperties>
-                                <webdriver.test.host>testHost</webdriver.test.host>
+                                <webdriver.test.host>${webdriver.test.host}</webdriver.test.host>
                             </systemProperties>
                             <testArgs>
                                 <testArg>-runStyle</testArg>
-                                <testArg>org.gwtproject.junit.RunStyleWebDriver:http://localhost:4444?firefox,chrome</testArg>
+                                <testArg>org.gwtproject.junit.RunStyleWebDriver:http://${webdriver.hub.host}:${webdriver.hub.port}?${webdriver.browsers}</testArg>
                             </testArgs>
                         </configuration>
                     </plugin>

--- a/gwt-core-gwt2-tests/pom.xml
+++ b/gwt-core-gwt2-tests/pom.xml
@@ -76,6 +76,11 @@
             <artifactId>gwt-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-remote-driver</artifactId>
+            <version>3.141.59</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -100,4 +105,27 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>github-ci-selenium</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>net.ltgt.gwt.maven</groupId>
+                        <artifactId>gwt-maven-plugin</artifactId>
+                        <configuration>
+                            <systemProperties>
+                                <webdriver.test.host>testHost</webdriver.test.host>
+                            </systemProperties>
+                            <testArgs>
+                                <testArg>-runStyle</testArg>
+                                <testArg>org.gwtproject.junit.RunStyleWebDriver:http://localhost:4444?firefox,chrome</testArg>
+                            </testArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/gwt-core-gwt2-tests/src/test/java/org/gwtproject/junit/RunStyleWebDriver.java
+++ b/gwt-core-gwt2-tests/src/test/java/org/gwtproject/junit/RunStyleWebDriver.java
@@ -1,112 +1,134 @@
+/*
+ * Copyright © 2019 The GWT Project Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.gwtproject.junit;
 
 import com.google.gwt.core.ext.TreeLogger;
 import com.google.gwt.core.ext.UnableToCompleteException;
 import com.google.gwt.junit.JUnitShell;
 import com.google.gwt.junit.RunStyle;
+import java.net.*;
+import java.util.ArrayList;
+import java.util.List;
 import org.openqa.selenium.Platform;
 import org.openqa.selenium.remote.DesiredCapabilities;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
-import java.net.*;
-import java.util.ArrayList;
-import java.util.List;
-
 public class RunStyleWebDriver extends RunStyle {
 
-    private List<RemoteWebDriver> browsers = new ArrayList<>();
-    private Thread keepalive;
+  private List<RemoteWebDriver> browsers = new ArrayList<>();
+  private Thread keepalive;
 
-    public RunStyleWebDriver(JUnitShell shell) {
-        super(shell);
+  public RunStyleWebDriver(JUnitShell shell) {
+    super(shell);
+  }
+
+  @Override
+  public int initialize(String args) {
+    if (args == null || args.length() == 0) {
+      getLogger()
+          .log(
+              TreeLogger.ERROR,
+              "WebDriver runstyle requires a parameter of the form protocol://hostname:port?browser1[,browser2]");
+      return -1;
+    }
+    String[] parts = args.split("\\?");
+    URL remoteAddress = null;
+    try {
+      remoteAddress = new URL(parts[0] + "/wd/hub");
+    } catch (MalformedURLException e) {
+      getLogger().log(TreeLogger.ERROR, e.getMessage(), e);
+      return -1;
     }
 
-    @Override
-    public int initialize(String args) {
-        if (args == null || args.length() == 0) {
-            getLogger().log(TreeLogger.ERROR, "WebDriver runstyle requires a parameter of the form protocol://hostname:port?browser1[,browser2]");
-            return -1;
-        }
-        String[] parts = args.split("\\?");
-        URL remoteAddress = null;
-        try {
-            remoteAddress = new URL(parts[0] + "/wd/hub");
-        } catch (MalformedURLException e) {
-            getLogger().log(TreeLogger.ERROR, e.getMessage(), e);
-            return -1;
-        }
+    // build each driver based on parts[1].split(",")
+    String[] browserNames = parts[1].split(",");
 
-        // build each driver based on parts[1].split(",")
-        String[] browserNames = parts[1].split(",");
+    for (String browserName : browserNames) {
+      DesiredCapabilities capabilities = new DesiredCapabilities(browserName, "", Platform.ANY);
 
-        for (String browserName : browserNames) {
-            DesiredCapabilities capabilities = new DesiredCapabilities(browserName, "", Platform.ANY);
-
-            try {
-                RemoteWebDriver wd = new RemoteWebDriver(remoteAddress, capabilities);
-                browsers.add(wd);
-            } catch (Exception exception) {
-                getLogger().log(TreeLogger.ERROR, "Failed to find desired browser", exception);
-                return -1;
-            }
-        }
-
-        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
-            if (keepalive != null) {
-                keepalive.interrupt();
-            }
-            for (RemoteWebDriver browser : browsers) {
-                try {
-                    browser.quit();
-                } catch (Exception ignored) {
-                    // ignore, we're shutting down, continue shutting down others
-                }
-            }
-        }));
-        return browsers.size();
+      try {
+        RemoteWebDriver wd = new RemoteWebDriver(remoteAddress, capabilities);
+        browsers.add(wd);
+      } catch (Exception exception) {
+        getLogger().log(TreeLogger.ERROR, "Failed to find desired browser", exception);
+        return -1;
+      }
     }
 
-    @Override
-    public void launchModule(String moduleName) throws UnableToCompleteException {
-        // since WebDriver.get is blocking, start a keepalive thread first
-        keepalive = new Thread(() -> {
-            while (true) {
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread(
+                () -> {
+                  if (keepalive != null) {
+                    keepalive.interrupt();
+                  }
+                  for (RemoteWebDriver browser : browsers) {
+                    try {
+                      browser.quit();
+                    } catch (Exception ignored) {
+                      // ignore, we're shutting down, continue shutting down others
+                    }
+                  }
+                }));
+    return browsers.size();
+  }
+
+  @Override
+  public void launchModule(String moduleName) throws UnableToCompleteException {
+    // since WebDriver.get is blocking, start a keepalive thread first
+    keepalive =
+        new Thread(
+            () -> {
+              while (true) {
                 try {
-                    Thread.sleep(1000);
+                  Thread.sleep(1000);
                 } catch (InterruptedException e) {
-                    break;
+                  break;
                 }
                 for (RemoteWebDriver browser : browsers) {
-                    browser.getTitle();// as in RunStyleSelenium, simple way to poll the browser
+                  browser.getTitle(); // as in RunStyleSelenium, simple way to poll the browser
                 }
-            }
-        });
-        keepalive.setDaemon(true);
-        keepalive.start();
-        for (RemoteWebDriver browser : browsers) {
-            browser.get(shell.getModuleUrl(moduleName));
-        }
+              }
+            });
+    keepalive.setDaemon(true);
+    keepalive.start();
+    for (RemoteWebDriver browser : browsers) {
+      browser.get(shell.getModuleUrl(moduleName));
     }
+  }
 
-    /**
-     * Work-around until GWT's JUnitShell handles IPv6 addresses correctly.
-     * https://groups.google.com/d/msg/google-web-toolkit/jLGhwUrKVRY/eQaDO6EUqdYJ
-     */
-    public String getLocalHostName() {
-        String host = System.getProperty("webdriver.test.host");
-        if (host != null) {
-            return host;
-        }
-        InetAddress a;
-        try {
-            a = InetAddress.getLocalHost();
-        } catch (UnknownHostException e) {
-            throw new RuntimeException("Unable to determine my ip address", e);
-        }
-        if (a instanceof Inet6Address) {
-            return "[" + a.getHostAddress() + "]";
-        } else {
-            return a.getHostAddress();
-        }
+  /**
+   * Work-around until GWT's JUnitShell handles IPv6 addresses correctly.
+   * https://groups.google.com/d/msg/google-web-toolkit/jLGhwUrKVRY/eQaDO6EUqdYJ
+   */
+  public String getLocalHostName() {
+    String host = System.getProperty("webdriver.test.host");
+    if (host != null) {
+      return host;
     }
+    InetAddress a;
+    try {
+      a = InetAddress.getLocalHost();
+    } catch (UnknownHostException e) {
+      throw new RuntimeException("Unable to determine my ip address", e);
+    }
+    if (a instanceof Inet6Address) {
+      return "[" + a.getHostAddress() + "]";
+    } else {
+      return a.getHostAddress();
+    }
+  }
 }

--- a/gwt-core-gwt2-tests/src/test/java/org/gwtproject/junit/RunStyleWebDriver.java
+++ b/gwt-core-gwt2-tests/src/test/java/org/gwtproject/junit/RunStyleWebDriver.java
@@ -1,0 +1,112 @@
+package org.gwtproject.junit;
+
+import com.google.gwt.core.ext.TreeLogger;
+import com.google.gwt.core.ext.UnableToCompleteException;
+import com.google.gwt.junit.JUnitShell;
+import com.google.gwt.junit.RunStyle;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.remote.DesiredCapabilities;
+import org.openqa.selenium.remote.RemoteWebDriver;
+
+import java.net.*;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RunStyleWebDriver extends RunStyle {
+
+    private List<RemoteWebDriver> browsers = new ArrayList<>();
+    private Thread keepalive;
+
+    public RunStyleWebDriver(JUnitShell shell) {
+        super(shell);
+    }
+
+    @Override
+    public int initialize(String args) {
+        if (args == null || args.length() == 0) {
+            getLogger().log(TreeLogger.ERROR, "WebDriver runstyle requires a parameter of the form protocol://hostname:port?browser1[,browser2]");
+            return -1;
+        }
+        String[] parts = args.split("\\?");
+        URL remoteAddress = null;
+        try {
+            remoteAddress = new URL(parts[0] + "/wd/hub");
+        } catch (MalformedURLException e) {
+            getLogger().log(TreeLogger.ERROR, e.getMessage(), e);
+            return -1;
+        }
+
+        // build each driver based on parts[1].split(",")
+        String[] browserNames = parts[1].split(",");
+
+        for (String browserName : browserNames) {
+            DesiredCapabilities capabilities = new DesiredCapabilities(browserName, "", Platform.ANY);
+
+            try {
+                RemoteWebDriver wd = new RemoteWebDriver(remoteAddress, capabilities);
+                browsers.add(wd);
+            } catch (Exception exception) {
+                getLogger().log(TreeLogger.ERROR, "Failed to find desired browser", exception);
+                return -1;
+            }
+        }
+
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            if (keepalive != null) {
+                keepalive.interrupt();
+            }
+            for (RemoteWebDriver browser : browsers) {
+                try {
+                    browser.quit();
+                } catch (Exception ignored) {
+                    // ignore, we're shutting down, continue shutting down others
+                }
+            }
+        }));
+        return browsers.size();
+    }
+
+    @Override
+    public void launchModule(String moduleName) throws UnableToCompleteException {
+        // since WebDriver.get is blocking, start a keepalive thread first
+        keepalive = new Thread(() -> {
+            while (true) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    break;
+                }
+                for (RemoteWebDriver browser : browsers) {
+                    browser.getTitle();// as in RunStyleSelenium, simple way to poll the browser
+                }
+            }
+        });
+        keepalive.setDaemon(true);
+        keepalive.start();
+        for (RemoteWebDriver browser : browsers) {
+            browser.get(shell.getModuleUrl(moduleName));
+        }
+    }
+
+    /**
+     * Work-around until GWT's JUnitShell handles IPv6 addresses correctly.
+     * https://groups.google.com/d/msg/google-web-toolkit/jLGhwUrKVRY/eQaDO6EUqdYJ
+     */
+    public String getLocalHostName() {
+        String host = System.getProperty("webdriver.test.host");
+        if (host != null) {
+            return host;
+        }
+        InetAddress a;
+        try {
+            a = InetAddress.getLocalHost();
+        } catch (UnknownHostException e) {
+            throw new RuntimeException("Unable to determine my ip address", e);
+        }
+        if (a instanceof Inet6Address) {
+            return "[" + a.getHostAddress() + "]";
+        } else {
+            return a.getHostAddress();
+        }
+    }
+}


### PR DESCRIPTION
This is a fork of GWT's own SeleniumRunStyle, updated to use WebDriver so that recent selenium updates work with it. The github actions wiring is also updated to start a hub and two nodes, one chrome and one firefox, and the gwt2 tests run once in each browwser.

Still needs docs in the readme to show how to use this locally (either by launching the selenium server directly or through docker.

If we think this is generally a good idea, we should move the class to its own reusable module in case of later changes and to keep documentation all in one place.