### PR TITLE
Cast arrays to JsArrayLike

### DIFF
--- a/gwt-core-gwt2-tests/pom.xml
+++ b/gwt-core-gwt2-tests/pom.xml
@@ -47,7 +47,7 @@
     <properties>
         <maven.gwt.plugin>1.0.0</maven.gwt.plugin>
 
-        <gwt.version>2.9.0</gwt.version>
+        <gwt.version>2.10.0</gwt.version>
     </properties>
 
     <dependencies>

--- a/gwt-core-gwt2-tests/src/test/java/org/gwtproject/core/client/JsArrayTest.java
+++ b/gwt-core-gwt2-tests/src/test/java/org/gwtproject/core/client/JsArrayTest.java
@@ -212,6 +212,22 @@ public class JsArrayTest extends GWTTestCase {
     assertEquals(0, jsArray.length());
   }
 
+  /**
+   * Checks that get, length and set methods work even if the JS object
+   * is not actual Array
+   */
+  public void testFakeArray() {
+    JsArray<JsPoint> points = makeFakeArray();
+    points.set(0, makeJsPoint(1, 2));
+    JsPoint pt = points.get(0);
+    assertEquals(1, pt.x());
+    assertEquals(7, points.length());
+  }
+
+  private native JsArray<JsPoint> makeFakeArray() /*-{
+    return {length: 7}
+  }-*/;
+
   private native JsArray<JsPoint> makeJsArray() /*-{
       return [
         { x: 0, y: 1, toString: function() { return 'JsPoint';} },

--- a/gwt-core/src/main/java/org/gwtproject/core/client/JsArray.java
+++ b/gwt-core/src/main/java/org/gwtproject/core/client/JsArray.java
@@ -18,6 +18,7 @@ package org.gwtproject.core.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import jsinterop.base.JsArrayLike;
 
 /**
  * A simple wrapper around a homogeneous native array of {@link
@@ -50,7 +51,7 @@ public class JsArray<T extends JavaScriptObject> extends JavaScriptObject {
    */
   @JsOverlay
   public final T get(int index) {
-    return this.<elemental2.core.JsArray<T>>cast().getAt(index);
+    return this.<JsArrayLike<T>>cast().getAt(index);
   }
 
   /**
@@ -85,7 +86,7 @@ public class JsArray<T extends JavaScriptObject> extends JavaScriptObject {
    */
   @JsOverlay
   public final int length() {
-    return this.<elemental2.core.JsArray<T>>cast().length;
+    return this.<JsArrayLike<T>>cast().getLength();
   }
 
   /**
@@ -106,7 +107,7 @@ public class JsArray<T extends JavaScriptObject> extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, T value) {
-    this.<elemental2.core.JsArray<T>>cast().setAt(index, value);
+    this.<JsArrayLike<T>>cast().setAt(index, value);
   }
 
   /**

--- a/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayBoolean.java
+++ b/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayBoolean.java
@@ -18,6 +18,7 @@ package org.gwtproject.core.client;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import jsinterop.base.JsArrayLike;
 
 /**
  * A simple wrapper around a homogeneous native array of boolean values.
@@ -46,7 +47,7 @@ public class JsArrayBoolean extends JavaScriptObject {
    */
   @JsOverlay
   public final boolean get(int index) {
-    return this.<elemental2.core.JsArray<Boolean>>cast().getAt(index);
+    return this.<JsArrayLike<Boolean>>cast().getAt(index);
   }
 
   /**
@@ -81,7 +82,7 @@ public class JsArrayBoolean extends JavaScriptObject {
    */
   @JsOverlay
   public final int length() {
-    return this.<elemental2.core.JsArray<Boolean>>cast().length;
+    return this.<JsArrayLike<Boolean>>cast().getLength();
   }
 
   /**
@@ -102,7 +103,7 @@ public class JsArrayBoolean extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, boolean value) {
-    this.<elemental2.core.JsArray<Boolean>>cast().setAt(index, value);
+    this.<JsArrayLike<Boolean>>cast().setAt(index, value);
   }
 
   /**

--- a/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayInteger.java
+++ b/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayInteger.java
@@ -19,6 +19,7 @@ import elemental2.core.JsArray;
 import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
+import jsinterop.base.JsArrayLike;
 
 /**
  * A simple wrapper around a homogeneous native array of integer values.
@@ -49,7 +50,7 @@ public class JsArrayInteger extends JavaScriptObject {
    */
   @JsOverlay
   public final int get(int index) {
-    return (int) (double) this.<JsArray<Double>>cast().getAt(index);
+    return (int) (double) this.<JsArrayLike<Double>>cast().getAt(index);
   }
 
   /**
@@ -84,7 +85,7 @@ public class JsArrayInteger extends JavaScriptObject {
    */
   @JsOverlay
   public final int length() {
-    return this.<JsArray<Double>>cast().length;
+    return this.<JsArrayLike<Double>>cast().getLength();
   }
 
   /**
@@ -105,7 +106,7 @@ public class JsArrayInteger extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, int value) {
-    this.<JsArray<Double>>cast().setAt(index, (double) value);
+    this.<JsArrayLike<Double>>cast().setAt(index, (double) value);
   }
 
   /**

--- a/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayMixed.java
+++ b/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayMixed.java
@@ -20,6 +20,7 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
+import jsinterop.base.JsArrayLike;
 
 /**
  * A simple wrapper around an heterogeneous native array of values.
@@ -49,7 +50,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final boolean getBoolean(int index) {
-    return Js.isTruthy(this.<JsArray<Object>>cast().getAtAsAny(index));
+    return Js.isTruthy(this.<JsArrayLike<Object>>cast().getAtAsAny(index));
   }
 
   /**
@@ -60,7 +61,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final double getNumber(int index) {
-    return Js.coerceToDouble(this.<JsArray<Object>>cast().getAtAsAny(index));
+    return Js.coerceToDouble(this.<JsArrayLike<Object>>cast().getAtAsAny(index));
   }
 
   /**
@@ -72,8 +73,8 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final <T extends JavaScriptObject> T getObject(int index) {
-    return this.<JsArray<Object>>cast().getAt(index) != null
-        ? this.<JsArray<Object>>cast().getAtAsAny(index).<T>cast()
+    return this.<JsArrayLike<Object>>cast().getAt(index) != null
+        ? this.<JsArrayLike<Object>>cast().getAtAsAny(index).<T>cast()
         : null;
   }
 
@@ -85,7 +86,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final String getString(int index) {
-    Object value = this.<JsArray<Object>>cast().getAt(index);
+    Object value = this.<JsArrayLike<Object>>cast().getAt(index);
     return value == null ? null : value.toString();
   }
 
@@ -121,7 +122,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final int length() {
-    return this.<JsArray<Object>>cast().length;
+    return this.<JsArrayLike<Object>>cast().getLength();
   }
 
   /**
@@ -163,7 +164,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, boolean value) {
-    this.<JsArray<Object>>cast().setAt(index, value);
+    this.<JsArrayLike<Object>>cast().setAt(index, value);
   }
 
   /**
@@ -177,7 +178,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, double value) {
-    this.<JsArray<Object>>cast().setAt(index, value);
+    this.<JsArrayLike<Object>>cast().setAt(index, value);
   }
 
   /**
@@ -191,7 +192,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, JavaScriptObject value) {
-    this.<JsArray<Object>>cast().setAt(index, value);
+    this.<JsArrayLike<Object>>cast().setAt(index, value);
   }
 
   /**
@@ -205,7 +206,7 @@ public class JsArrayMixed extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, String value) {
-    this.<JsArray<Object>>cast().setAt(index, value);
+    this.<JsArrayLike<Object>>cast().setAt(index, value);
   }
 
   /**

--- a/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayNumber.java
+++ b/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayNumber.java
@@ -20,6 +20,7 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
+import jsinterop.base.JsArrayLike;
 
 /**
  * A simple wrapper around a homogeneous native array of numeric values.
@@ -51,7 +52,7 @@ public class JsArrayNumber extends JavaScriptObject {
    */
   @JsOverlay
   public final double get(int index) {
-    return this.<JsArray<Number>>cast().getAt(index).doubleValue();
+    return this.<JsArrayLike<Number>>cast().getAt(index).doubleValue();
   }
 
   /**
@@ -86,7 +87,7 @@ public class JsArrayNumber extends JavaScriptObject {
    */
   @JsOverlay
   public final int length() {
-    return this.<JsArray<Number>>cast().length;
+    return this.<JsArrayLike<Number>>cast().getLength();
   }
 
   /**
@@ -107,7 +108,7 @@ public class JsArrayNumber extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, double value) {
-    this.<JsArray<Number>>cast().setAt(index, Js.uncheckedCast(value));
+    this.<JsArrayLike<Number>>cast().setAt(index, Js.uncheckedCast(value));
   }
 
   /**

--- a/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayString.java
+++ b/gwt-core/src/main/java/org/gwtproject/core/client/JsArrayString.java
@@ -20,6 +20,7 @@ import jsinterop.annotations.JsOverlay;
 import jsinterop.annotations.JsPackage;
 import jsinterop.annotations.JsType;
 import jsinterop.base.Js;
+import jsinterop.base.JsArrayLike;
 
 /**
  * A simple wrapper around a homogeneous native array of string values.
@@ -45,7 +46,7 @@ public class JsArrayString extends JavaScriptObject {
    */
   @JsOverlay
   public final String get(int index) {
-    String value = this.<JsArray<String>>cast().getAt(index);
+    String value = this.<JsArrayLike<String>>cast().getAt(index);
     return value == null ? null : value;
   }
 
@@ -81,7 +82,7 @@ public class JsArrayString extends JavaScriptObject {
    */
   @JsOverlay
   public final int length() {
-    return this.<JsArray<String>>cast().length;
+    return this.<JsArrayLike<String>>cast().getLength();
   }
 
   /**
@@ -102,7 +103,7 @@ public class JsArrayString extends JavaScriptObject {
    */
   @JsOverlay
   public final void set(int index, String value) {
-    this.<JsArray<String>>cast().setAt(index, Js.uncheckedCast(value));
+    this.<JsArrayLike<String>>cast().setAt(index, Js.uncheckedCast(value));
   }
 
   /**


### PR DESCRIPTION
This brings the behavior closer to current GWT 2.10 version -- avoiding cast to `elemental2.core.JsArray` means that `isArray` check is not used in superdev mode.

Fixes https://github.com/gwtproject/gwt-event-dom/issues/12