### PR TITLE
Fix test comment formatting

### DIFF
--- a/gwt-core-gwt2-tests/src/test/java/org/gwtproject/core/client/JsArrayTest.java
+++ b/gwt-core-gwt2-tests/src/test/java/org/gwtproject/core/client/JsArrayTest.java
@@ -212,10 +212,7 @@ public class JsArrayTest extends GWTTestCase {
     assertEquals(0, jsArray.length());
   }
 
-  /**
-   * Checks that get, length and set methods work even if the JS object
-   * is not actual Array
-   */
+  /** Checks that get, length and set methods work even if the JS object is not actual Array */
   public void testFakeArray() {
     JsArray<JsPoint> points = makeFakeArray();
     points.set(0, makeJsPoint(1, 2));

--- a/gwt-core-j2cl-tests/pom.xml
+++ b/gwt-core-j2cl-tests/pom.xml
@@ -44,13 +44,13 @@
     <inceptionYear>2019</inceptionYear>
 
     <properties>
-        <maven.j2cl.plugin>0.16-SNAPSHOT</maven.j2cl.plugin>
+        <maven.j2cl.plugin>0.20</maven.j2cl.plugin>
         <maven.resource.plugin>3.1.0</maven.resource.plugin>
 
         <!-- CI -->
         <vertispan.j2cl.repo.url>https://repo.vertispan.com/j2cl/</vertispan.j2cl.repo.url>
 
-        <j2cl.version>0.8-SNAPSHOT</j2cl.version>
+        <j2cl.version>0.11.0-9336533b6</j2cl.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
@niloc132 Sorry for breaking the build in #19

Version bump was needed for j2cl tests to work on Windows.